### PR TITLE
vendor/base58: remove unused headers.

### DIFF
--- a/vendor/base58/base58.c
+++ b/vendor/base58/base58.c
@@ -5,12 +5,6 @@
  * under the terms of the standard MIT license.  See COPYING for more details.
  */
 
-#ifndef WIN32
-#include <arpa/inet.h>
-#else
-#include <winsock2.h>
-#endif
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>


### PR DESCRIPTION
These unused headers have been removed. They are not included in the CI and disrupt deployment.