### PR TITLE
make: remove extra include

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ include $(BOLOS_SDK)/Makefile.defines
 
 MAJOR = 1
 MINOR = 0
-PATCH = 5
+PATCH = 6
 
 #
 # App

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,6 @@ LD := $(GCCPATH)arm-none-eabi-gcc
 CFLAGS += -O3 -Os
 CFLAGS += -Wno-typedef-redefinition
 CFLAGS += -Wno-incompatible-pointer-types-discards-qualifiers
-CFLAGS += -I/usr/include/
 LDFLAGS += -O3 -Os
 LDLIBS += -lm -lgcc -lc
 


### PR DESCRIPTION
# Checklist
<!-- Put an `x` in each box when you have completed the items. -->
- [ ] App update process has been followed (security review is on hold)
- [x] Target branch is `develop`
- [x] Application version has been bumped <!-- required if your changes are to be deployed -->

# Overview

The latest build for Nano X (os 2.2.3, app 1.0.5) isn't working. While the app loads and some commands work (getAccountXPUB), attempting to sign any transaction crashes the app, and the only way to recover is by restarting the device.

With help from Ledger discord ([conversation](https://discord.com/channels/885256081289379850/1001418766682431508/1184456209508606012)) (they were a huge help, thanks!), the issue seems to be an unnecessary include `/usr/include`.

Turns out all new builds have this issue, even when building with older SDKs and for other models (probably an environment change). So it's currently just the Nano X, but will affect all future versions.

# Details

This is reproducible with the latest `ledger-app-builder-lite` docker image on this app's master HEAD:
`docker run --rm -ti -v "$(realpath .):/app" --user $(id -u):$(id -g) ghcr.io/ledgerhq/ledger-app-builder/ledger-app-builder-lite:latest`

speculos segfault crash:
```
10:12:23.548:seproxyhal: printf: BLE_power 0
10:12:23.548:seproxyhal: printf: BLE_power 1
10:12:23.548:seproxyhal: printf: INIT START
10:12:23.608:werkzeug: 172.17.0.1 - - [13/Dec/2023 10:12:23] "GET /screenshot?force=1702462343558 HTTP/1.1" 200 -
10:12:27.180:apdu: > e042040015058000002c800014eb800000000000000100000000
10:12:27.314:apdu: < 030267926f9f7c9ed6c79093423ab310d2a323fdf3f0e9065ac877239dce8eb1980000009000
10:12:27.316:apdu: > e042040015058000002c800014eb800000000000000000000000
10:12:27.422:apdu: < 03c41945e7aa7fde1d0cb8d38258998b89797787567c2336112aa9c3c9c95d16240000009000
10:12:27.424:apdu: > e0440500c200000000000000000202010000058000002c800014eb8000000000000001000000014cfcb36eced3bcb8f2fe41fd4ac90644ced2b8ba2473583f55fbb3ad632f5aea00000000ffffffff10bf9a3b000000004cfcb36eced3bcb8f2fe41fd4ac90644ced2b8ba2473583f55fbb3ad632f5aea01000000ffffffff00ca9a3b00000000f8ae9a3b00000000001476555826b1d5f9001f0ddf5a0c6c08f7aa4b5f0f000000ca9a3b0000000000143e79bcdf0f6fbd772dbf0a95c1e90af2ef5db3440000
[-] The app crashed with signal 11
```